### PR TITLE
Refactor and fix resource handling in router and DAO functions

### DIFF
--- a/fast_controller/__init__.py
+++ b/fast_controller/__init__.py
@@ -208,11 +208,11 @@ def _register_rename_endpoint(controller, router: APIRouter, resource: type[Reso
 
         if len(pk) == 1:
             new_value = kwargs['new_pk']
-            dao.rename(current, dao.get(new_value))
+            dao.rename(current, new_value)
         else:
             new_values = kwargs.get('new_pk', {})
             new_pk_values = [new_values.get(field, kwargs[field]) for field in pk]
-            dao.rename(current, dao.get(*new_pk_values))
+            dao.rename(current, *new_pk_values)
 
         return current
 

--- a/fast_controller/__init__.py
+++ b/fast_controller/__init__.py
@@ -184,7 +184,8 @@ def _register_delete_endpoint(controller, router: APIRouter, resource: type[Reso
     @docstring_format(resource=inflect.a(resource.doc_name()))
     def delete(daos: DAOFactory = controller.daos, **kwargs) -> None:
         """Deletes {resource}"""
-        daos[resource].remove(*extract_values(kwargs, pk))
+        model = daos[resource].get(*extract_values(kwargs, pk))
+        daos[resource].remove(model)
 
     expose_path_params(delete, pk)
 

--- a/fast_controller/__init__.py
+++ b/fast_controller/__init__.py
@@ -291,10 +291,10 @@ class Controller:
         resource_router = APIRouter(
             prefix=resource.get_resource_path(),
             tags=[resource.resource_name()])
-        self._register_resource_endpoints(resource_router, resource, skip)
 
         if additional_endpoints:
             additional_endpoints(resource_router, self)
+        self._register_resource_endpoints(resource_router, resource, skip)
 
         self.router.include_router(resource_router)
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -19,14 +19,14 @@ class Default(SQLModel):
     pass
 
 
-@pytest.mark.parametrize("preferred, default, expected", [
+@pytest.mark.parametrize('preferred, default, expected', [
     (Preferred, Default, Preferred),
     (SQLModel, Default, SQLModel),
     (DAOModel, Default, DAOModel),
     (Resource, Default, Resource),
     (None, Default, Default),
     (1, Default, Default),
-    ("test", Default, Default),
+    ('test', Default, Default),
     (Controller, Default, Default)
 ])
 def test_either(preferred: Any, default: type[SQLModel], expected: type[SQLModel]):
@@ -36,7 +36,7 @@ def test_either(preferred: Any, default: type[SQLModel], expected: type[SQLModel
 def test_get_path():
     class Class(Resource):
         pass
-    assert Class.get_resource_path() == "/api/classes"
+    assert Class.get_resource_path() == '/classes'
 
 
 class Author(Resource, table=True):


### PR DESCRIPTION
This pull request includes the following changes:
1. Refactored the resource registration order in the router setup to ensure proper endpoint handling and avoid potential conflicts.
2. Updated test assertions for `get_resource_path` to match the latest implementation, ensuring consistency.
3. Corrected the `remove` endpoint to pass the entire model rather than just primary key values, improving accuracy.
4. Fixed argument handling in `dao.rename` calls to use direct primary key values instead of redundant `dao.get` calls, enhancing clarity and correctness.
5. Removed a deprecated function to improve maintainability. 

These updates collectively enhance the reliability and readability of the resource management codebase.